### PR TITLE
feat: add search context tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,11 @@ GITHUB_TOKEN=
 OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_CONSOLE_EXPORT=1
 WORKSPACE_DIR=/workspace/jobs
+
+# Search-context limits
+# maximum number of file snippets to return
+SEARCH_CONTEXT_MAX_RESULTS=20
+# maximum total characters across all snippets
+SEARCH_CONTEXT_MAX_CHARS=8000
+# lines of context to include around each match
+SEARCH_CONTEXT_LINES=2

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ End-to-end automation from a **requirement template → PR**, exposed via an asy
 - Parse requirement YAML
 - Clone repo, create feature branch
 - Plan and generate code + tests via LLM (structured output)
+- Optional codebase search tool for additional context to generation
 - Build & test in ephemeral Docker runner
 - Commit, push, and open a PR
 - Return a structured response (status, pr_url, logs)
@@ -25,7 +26,8 @@ strands-demo
 │   │   ├── code_tools.py
 │   │   ├── git_tools.py
 │   │   ├── github_tools.py
-│   │   └── requirements_tool.py
+│   │   ├── requirements_tool.py
+│   │   └── search_context.py
 │   └── utils.py
 ├── docker-compose.yml
 ├── Dockerfile
@@ -295,3 +297,5 @@ docker compose up --build -d
 - Build/test isolation via Docker runner; configure image+command in the template.
 - Optional OpenTelemetry export if `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
 - Swap providers: Bedrock (default with AWS creds), OpenAI, or local Ollama.
+- Configure search-context limits via `SEARCH_CONTEXT_MAX_RESULTS`,
+  `SEARCH_CONTEXT_MAX_CHARS`, and `SEARCH_CONTEXT_LINES` (see `.env.example`).

--- a/agent_main.py
+++ b/agent_main.py
@@ -16,6 +16,7 @@ from app.tools.requirements_tool import load_requirement  # tool (kept)
 from app.tools.git_tools import prepare_workspace, commit_and_push
 from app.tools.code_tools import plan_changes, generate_changes, apply_changes, build_and_test
 from app.tools.github_tools import open_pull_request
+from app.tools.search_context import search_context
 from app.orchestrator import run_requirement_pipeline
 from app import runtime
 
@@ -50,6 +51,7 @@ def make_agent() -> Agent:
             build_and_test,
             commit_and_push,
             open_pull_request,
+            search_context,
         ],
     )
     runtime.set_agent(agent)

--- a/app/tools/search_context.py
+++ b/app/tools/search_context.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from typing import List
+
+from strands import tool
+
+log = logging.getLogger(__name__)
+if not log.handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter("%(asctime)s | %(levelname)s | %(message)s"))
+    log.addHandler(_h)
+log.setLevel(os.getenv("LOG_LEVEL", "INFO").upper())
+
+_DEFAULT_MAX_RESULTS = int(os.getenv("SEARCH_CONTEXT_MAX_RESULTS", "20"))
+_DEFAULT_MAX_CHARS = int(os.getenv("SEARCH_CONTEXT_MAX_CHARS", "8000"))
+_DEFAULT_CONTEXT_LINES = int(os.getenv("SEARCH_CONTEXT_LINES", "2"))
+
+@tool(name="search_context", description="Search repository code and return snippets for additional context.")
+def search_context(
+    repo_dir: str,
+    query: str,
+    max_results: int = _DEFAULT_MAX_RESULTS,
+    max_chars: int = _DEFAULT_MAX_CHARS,
+    context_lines: int = _DEFAULT_CONTEXT_LINES,
+) -> dict:
+    """Search repo for ``query`` and return code snippets.
+
+    Uses ripgrep to locate matching lines, then reads surrounding context from disk.
+    Output is capped by ``max_results`` and ``max_chars`` to avoid oversized payloads.
+    """
+    if not query.strip():
+        return {"query": query, "results": [], "truncated": False}
+
+    cmd = ["rg", "--json", query, repo_dir]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    snippets: List[str] = []
+    total = 0
+    truncated = False
+
+    try:
+        for line in proc.stdout:  # type: ignore[union-attr]
+            if len(snippets) >= max_results or total >= max_chars:
+                truncated = True
+                break
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") != "match":
+                continue
+            path = event["data"]["path"]["text"]
+            line_no = event["data"]["line_number"]
+            abs_path = os.path.join(repo_dir, path)
+            try:
+                with open(abs_path, "r", encoding="utf-8", errors="ignore") as fh:
+                    lines = fh.readlines()
+            except OSError as ex:
+                log.warning("search_context: failed to read %s: %s", abs_path, ex)
+                continue
+            start = max(0, line_no - 1 - context_lines)
+            end = min(len(lines), line_no + context_lines)
+            snippet_lines = [f"# {path}"]
+            for idx in range(start, end):
+                prefix = ">" if idx == line_no - 1 else " "
+                snippet_lines.append(f"{prefix}{idx+1:>4}: {lines[idx].rstrip()}")
+            snippet = "\n".join(snippet_lines)
+            if total + len(snippet) > max_chars:
+                snippet = snippet[: max(0, max_chars - total)]
+                truncated = True
+            snippets.append(snippet)
+            total += len(snippet)
+            if truncated:
+                break
+    finally:
+        proc.kill()
+
+    return {"query": query, "results": snippets, "truncated": truncated}


### PR DESCRIPTION
## Summary
- add configurable `search_context` tool to surface repo snippets for codegen
- wire search tool into agent
- document search capability in README and env vars

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8290b4010832a9ff0fa4387ec25dc